### PR TITLE
the docker image was deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse:latest
+FROM opensuse/archive:latest
 
 # General information
 LABEL de.itsfullofstars.sapnwdocker.version="1.0.0"


### PR DESCRIPTION
the docker image was deprecated and the image name has changed to opensuse/archive link: https://hub.docker.com/r/opensuse/archive